### PR TITLE
Add Auferet alongside AI Dungeon

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,7 @@ Join the community! Contribute your favorite AI tools and help us grow. Found so
 - [This Image Does Not Exist](https://thisimagedoesnotexist.com/) - Test your ability to tell if an image is human or computer generated.
 - [Have I Been Trained?](https://haveibeentrained.com/) - Check if your image has been used to train popular AI art models.
 - [AI Dungeon](https://aidungeon.io/) - A text-based adventure-story game you direct (and star in) while the AI brings it to life.
+- [Auferet](https://auferet.com/) - AI game master for solo text adventures and tabletop-style RPGs, with persistent memory and your own uploaded lore.
 - [Clickable](https://www.clickable.so/) - Generate ads in seconds with AI. Beautiful, brand-consistent, and highly converting ads for all marketing channels.
 - [Scale Spellbook](https://scale.com/spellbook) - Build, compare, and deploy large language model apps with Scale Spellbook.
 - [Scenario](https://www.scenario.com/) - AI-generated gaming assets.


### PR DESCRIPTION
Adds **Auferet** to the Other / generative-AI list, next to AI Dungeon.

Auferet is an AI game master for solo text adventures and tabletop-style RPGs. It keeps a persistent memory of your story and lets you upload your own lore for a consistent world. It runs in the browser and as a published Android app. The entry matches the existing format.
