### PR TITLE
Add agent frameworks and browser/agent infra

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,12 @@ Join the community! Contribute your favorite AI tools and help us grow. Found so
 - [Codeium / Windsurf](https://windsurf.com/) - Codeium-style completions plus Windsurf editor: agentic coding flows with strong multi-file edits.
 - [Cursor](https://cursor.com/) - AI-native fork of VS Code with inline chat, agents, and deep codebase awareness.
 - [GitHub Copilot](https://github.com/features/copilot) - Inline suggestions, chat, and agents across major IDEs and GitHub.com.
+- [Microsoft Agent Framework](https://github.com/microsoft/agent-framework) - Microsoft's supported multi-agent successor to AutoGen for enterprise orchestration, MCP/A2A, and durable agent apps.
+- [PydanticAI](https://ai.pydantic.dev/) - Type-safe Python agent framework from the Pydantic team for structured tools, deps, and eval-friendly agent graphs.
+- [smolagents](https://github.com/huggingface/smolagents) - Hugging Face's minimal code-first agent library emphasizing small, readable agent loops and tool use.
+- [Browser Use](https://github.com/browser-use/browser-use) - Open-source library for LLM-driven browser automation (click, type, navigate) used widely in computer-use agent stacks.
+- [Browserbase](https://www.browserbase.com/) - Hosted headless browser infrastructure for web agents with stealth, sessions, and developer APIs.
+- [Tavily](https://www.tavily.com/) - Search API built for LLM/agent retrieval (clean snippets, citations) rather than consumer search UIs.
 
 ## 💻 Code Generation with AI
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds six Developer-Centric AI entries that were not already listed: Microsoft Agent Framework, PydanticAI, smolagents, Browser Use, Browserbase, and Tavily.

Hot Picks and all other sections are unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b7a6ec8b-c4ec-41bf-91de-7e145ba93fbc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b7a6ec8b-c4ec-41bf-91de-7e145ba93fbc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

