### PR TITLE
Fix Roblox GUI Maker description to match the live site

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Join the community! Contribute your favorite AI tools and help us grow. Found so
 - [MetaGPT](https://github.com/geekan/MetaGPT) - The Multi-Agent Framework: Given one line Requirement, return PRD, Design, Tasks, Repo
 - [Manus](https://manus.im/) - General autonomous agent product for multi-step research and execution tasks.
 - [Marblism](https://marblism.com) - Generate a SaaS boilerplate from a prompt.
-- [Roblox GUI Maker](https://robloxguimaker.dev/) - Free AI-assisted Roblox Studio GUI planner for ScreenGui layouts, HUDs, menus, and Lua UI starter-code ideas.
+- [Roblox GUI Maker](https://robloxguimaker.dev/) - AI prompt-to-GUI mockup planner for Roblox Studio ScreenGui layouts (shops, HUDs, inventories) with desktop/mobile preview.
 - [Lovable](https://lovable.dev/) - Prompt-to-app builder focused on polished full-stack prototypes and iterative product UIs.
 - [v0](https://v0.dev/) - Vercel's generative UI builder for React/Tailwind components and app scaffolds from prompts.
 - [MutahunterAI](https://github.com/codeintegrity-ai/mutahunter) - Accelerate developer productivity and code security with our open-source AI.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #3 ([chugzb](https://github.com/chugzb)'s Roblox GUI Maker listing), which we squash-merged as submitted for contributor attribution.

The original blurb implied Lua UI starter-code export. The live site at [robloxguimaker.dev](https://robloxguimaker.dev/) is a prompt-to-GUI **mockup** planner: AI-generated mockup images plus a structured ScreenGui plan, with desktop/mobile preview. Lua export is listed as coming soon.

Updated entry:

- [Roblox GUI Maker](https://robloxguimaker.dev/) - AI prompt-to-GUI mockup planner for Roblox Studio ScreenGui layouts (shops, HUDs, inventories) with desktop/mobile preview.

No other README lines were changed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8c9fade5-3e94-4cc6-8503-53863d1b11cb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8c9fade5-3e94-4cc6-8503-53863d1b11cb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

